### PR TITLE
Add timezone table

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.4
 
-RUN apk add --no-cache curl mysql mysql-client
+RUN apk add --no-cache curl mysql mysql-client tzdata
 
 RUN curl -o /usr/local/bin/gosu -sSL "https://github.com/tianon/gosu/releases/download/1.2/gosu-amd64"
 RUN chmod +x /usr/local/bin/gosu

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -30,6 +30,7 @@ fi
 
 chown mysql "$MYSQL_INITFILE"
 /usr/bin/mysqld_safe --user=root --init-file=$MYSQL_INITFILE
+/usr/bin/mysql_tzinfo_to_sql /usr/share/zoneinfo | /usr/bin/mysql -u root mysql
 rm -f $MYSQL_INITFILE
 
 exec gosu mysql "$@"


### PR DESCRIPTION
MySQL users `CONVERT_TZ` to convert datetime objects between timezones at the database level. We're making use of the `convox/mysql` Docker image with a Django project which constructs such SQL queries when the `USE_TZ` setting is enabled, resulting in empty queries where we should get results.

This PR would introduce the `tzdata` package (approx 3.2Mb) to the base image and would leverage it in the docker-entrypoint by converting the timezone information into SQL queries and passing them to the `mysql` client for insertion.

The result is data loaded into the following tables:
- `time_zone`
- `time_zone_name`
- `time_zone_transition`
- `time_zone_transition_type`